### PR TITLE
Coil Characterization: update results-directory, place output in subdirs

### DIFF
--- a/Coil_Characterization/Coil_Characterization-3.3.json
+++ b/Coil_Characterization/Coil_Characterization-3.3.json
@@ -48,8 +48,7 @@
       "id": "reportFile",
       "name": "reportFile",
       "path-template": "reportFile/[COIL]_*.pdf",
-      "path-template-stripped-extensions":[".txt"],
-      "value-key": "[OUTPUT_PDF]"
+      "path-template-stripped-extensions":[".txt"]
     },
     {
       "id": "comparison",

--- a/Coil_Characterization/Coil_Characterization-3.3.json
+++ b/Coil_Characterization/Coil_Characterization-3.3.json
@@ -3,7 +3,7 @@
   "tool-version": "3.3",
   "description": "Coil Characterization",
   "author": "VIP team",
-  "command-line": "if ! test \"$(basename [COIL] .txt)\" = \"$(head -1 [COIL])\"; then echo \"Invalid coil input: name mismatch\"; exit 1; fi && if test \"$(basename [COMPARISON])\" != comparison; then ln -sfT [COMPARISON] comparison; fi && echo \"before exec:\" && ls -l comparison/ && touch _start && caract_inside.sh [COIL] [FANTOM] [DATA] && echo \"after exec:\" && ls -l comparison/ reportFile/ && OUTPUTS=\"$(find comparison/ -newer _start -name [OUTPUT_MAT]) $(find reportFile/ -newer _start -name [OUTPUT_PDF])\" && echo \"found outputs: $OUTPUTS\" && cp $OUTPUTS ./",
+  "command-line": "if ! test \"$(basename [COIL] .txt)\" = \"$(head -1 [COIL])\"; then echo \"Invalid coil input: name mismatch\"; exit 1; fi && if test \"$(basename [COMPARISON])\" != comparison; then ln -sfT [COMPARISON] comparison; fi && echo \"before exec:\" && ls -l comparison/ && touch _start && caract_inside.sh [COIL] [FANTOM] [DATA] && echo \"after exec:\" && ls -l comparison/ reportFile/ && find comparison/ -not -newer _start -name \"$(basename [OUTPUT_MAT])\" -delete && echo \"after cleanup:\" && ls -l comparison/ reportFile/",
   "container-image": {
     "type": "docker",
     "image": "covid.creatis.insa-lyon.fr/vip-support/coil-caract:3.3",
@@ -38,7 +38,7 @@
       "id": "Comparison",
       "name": "Comparison",
       "type": "File",
-      "description": "Comparison directory containing mat files from previous executions. Please set \"Results directory\" above to the same value, to allow future reuse of the mat file that this execution will produce.",
+      "description": "Comparison directory containing mat files from previous executions. Please set \"Results directory\" above to the parent directory, to allow future reuse of the mat file that this execution will produce.",
       "value-key": "[COMPARISON]",
       "default-value": "/vip/Home/coilCharact/comparison"
     }
@@ -47,20 +47,22 @@
     {
       "id": "reportFile",
       "name": "reportFile",
-      "path-template": "[COIL]_*.pdf",
+      "path-template": "reportFile/[COIL]_*.pdf",
       "path-template-stripped-extensions":[".txt"],
       "value-key": "[OUTPUT_PDF]"
     },
     {
       "id": "comparison",
       "name": "comparison",
-      "path-template": "*_[COIL]_*.mat",
+      "path-template": "comparison/*_[COIL]_*.mat",
       "path-template-stripped-extensions":[".txt"],
       "value-key": "[OUTPUT_MAT]"
     }
   ],
 	"custom": {
     "vip:dot": ["Coil","Phantom","Data","Comparison"],
-    "vip:resultsDirectorySuffix":""
+    "vip:resultsDirectorySuffix":"",
+    "vip:resultsDirectoryDefault":"/vip/Home/coilCharact",
+    "vip:resultsDirectoryDescription":"Results will be placed in subdirectories: \"comparison\" for the .mat file, and \"reportFile\" for the .pdf file."
   }
 }

--- a/Coil_Characterization/README.md
+++ b/Coil_Characterization/README.md
@@ -3,12 +3,13 @@ The Coil Characterization app has a number of constraints, most of which are wor
 Constraints:
 - the app can take its own previous outputs as inputs in the comparison/ dir: solved by passing the comparison dir as input.
 - output files names are not fully expressible in advance: solved by using wildcards in the descriptor path templates for output files.
-- output files are created in subdirectories: solved by copying output files to the current directory. This might be improved later by preserving and transferring the whole output directory tree.
+- output files are created in subdirectories: solved by specifying relative subdirectory in path templates. This needs the execution environment to correctly handle such outputs.
 - the app uses the content (first line) of the coil input to name its outputs, but bosh can only use filenames. Both basename and first line should match in practice, so we enforce this with a check at the start of command-line.
 
 Known quirks and limitations:
-- input comparison dir and output "results-dir" should be identical in most cases, but we also accept that they differ: if so, outputs will just be placed in "results-dir", and the user is responsible for managing files location for future executions as needed.
-- in case of multiple parallel executions using the same coil id and sharing the same directories, the "find -newer" method might not differentiate between outputs. This should work, however, as long as the comparison/ dir is copied before execution (see script.sh), and kept independent for each job.
+- input comparison dir should be the "comparison" directory under "results-dir" in most cases (as indicated by default values), but we also accept that they differ: if so, outputs will just be placed in "results-dir", and the user is responsible for managing files location for future executions as needed.
+- when using wildcards in path-template, bosh only takes one arbitrary file matching the pattern (python glob semantics). So this can only be used to get a single output file per template, when the output name can't be known in advance. We handle this by removing all files older than the execution under comparison/ at the end of the execution. This also assumes that the app creates a single new mat file and a single new pdf file.
+- in case of multiple parallel executions using the same coil id and sharing the same directories, the `touch _start` + `find -newer` method might not differentiate between outputs. As for the previous point, things work as long as the comparison/ dir is copied before execution and kept independent for each job.
 - if a mat file for a given coil input already exists in comparison dir, only the `reportFile/*pdf` output is produced. This is still considered a successful execution, with a single output file.
 - the container image is currently not compatible with singularity, only with docker.
 
@@ -32,8 +33,8 @@ touch _start
 caract_inside.sh [COIL] [FANTOM] [DATA]
 # post-execution debug trace
 echo "after exec:" && ls -l comparison/ reportFile/
-# detect new outputs and copy them to ./
-OUTPUTS="$(find comparison/ -newer _start -name [OUTPUT_MAT]) $(find reportFile/ -newer _start -name [OUTPUT_PDF])"
-echo "found outputs: $OUTPUTS"
-cp $OUTPUTS ./
+# remove any mat file in comparison/ that is older than the execution,
+# so that remaining files can be correctly detected by bosh
+find comparison/ -not -newer _start -name "$(basename [OUTPUT_MAT])" -delete
+echo "after cleanup:" && ls -l comparison/ reportFile/
 ```


### PR DESCRIPTION
This updates the "Coil Characterization" descriptor to get closer to the legacy gwendia behavior of this app, where the `reportFile/*.pdf` and `comparison/*.mat` outputs are placed in separate subdirectories.

In order to work, this new descriptor needs :
- PR https://github.com/virtual-imaging-platform/GASW/pull/125 for subdirectories in outputs
- PR https://github.com/virtual-imaging-platform/VIP-portal/pull/586 for the two new resultsDir custom properties, and for folder inputs support in VIP-portal (name lookup for the `comparison` directory used as input)
- An upcoming GASW patch by Axel to support input directories download on Girder. It is sufficient to change the `parent-type` to `girder-client download --parent-type auto` in `downloadGirderFile`, however do note that this command will not create a local `comparison` folder when the remote folder is empty. So the `comparison` folder on Girder has to exist, and to be non-empty (or we'd to use the Girder API there to handle that case).
